### PR TITLE
Indented, sorted dump

### DIFF
--- a/namelist.py
+++ b/namelist.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 try:
     from collections import OrderedDict
 except ImportError:
@@ -70,7 +71,7 @@ class Namelist():
             block_lines = group_block.split('\n')
             group_name = block_lines.pop(0).strip()
 
-            group = {}
+            group = OrderedDict()
 
             for line in block_lines:
                 line = line.strip()
@@ -107,7 +108,13 @@ class Namelist():
                 except NoSingleValueFoundException as e:
                     # see we have several values inlined
                     if variable_value.count("'") in [0, 2]:
-                        variable_arr_entries = variable_value.split()
+                        if variable_value.count("(") != 0:  # if list of complex values
+                            variable_arr_entries = variable_value.split()
+                        else:
+                            # replacing ',' makes comma-separated arrays possible,
+                            # see unit test test_inline_array_comma
+                            # this fails if an array of complex numbers is comma-separated
+                            variable_arr_entries = variable_value.replace(',', ' ').split()
                     else:
                         # we need to be more careful with lines with escaped
                         # strings, since they might contained spaces
@@ -197,6 +204,7 @@ class Namelist():
         return "\n".join(lines)
 
     def _format_value(self, value):
+        is_python2 = sys.version_info < (3,0,0)
         if isinstance(value, bool):
             return value and '.true.' or '.false.'
         elif isinstance(value, int):
@@ -204,6 +212,8 @@ class Namelist():
         elif isinstance(value, float):
             return "%f" % value
         elif isinstance(value, str):
+            return "'%s'" % value
+        elif is_python2 and isinstance(value, unicode):  # needed if unicode literals are used
             return "'%s'" % value
         elif isinstance(value, complex):
             return "(%s,%s)" % (self._format_value(value.real), self._format_value(value.imag))
@@ -409,51 +419,60 @@ class ParsingTests(unittest.TestCase):
 
         self.assertEqual(dict(namelist.groups), expected_output)
 
-class ParsingTests(unittest.TestCase):
-    def test_single_value(self):
+
+    def test_inline_array_comma(self):
+        input_str = """
+                    &foo
+                    bar = 7.2, 4.3, 3.14,
+                    /
+                    """
+        expected_output = {'foo': {'bar':[7.2, 4.3, 3.14]}}
+        namelist = Namelist(input_str)
+
+        self.assertEqual(dict(namelist.groups), expected_output)
+
+
+    def test_dump_single_value(self):
         input_str = """&CCFMSIM_SETUP
-  CCFMrad=800.
+  CCFMrad = 800.000000
 /"""
         namelist = Namelist(input_str)
 
         self.assertEqual(namelist.dump(), input_str)
 
-    def test_multigroup(self):
+    def test_dump_multigroup(self):
         input_str = """&CCFMSIM_SETUP
-  CCFMrad=800.
+  CCFMrad = 800.000000
 /
 &GROUP2
-  R=500.
+  R = 500.000000
 /"""
         namelist = Namelist(input_str)
 
         self.assertEqual(namelist.dump(), input_str)
 
 
-    def test_array(self):
+    def test_dump_array(self):
         input_str = """&CCFMSIM_SETUP
-  var_trac_picture(1)='watcnew'
-  var_trac_picture(2)='watpnew'
-  var_trac_picture(3)='icecnew'
-  var_trac_picture(4)='granew'
-  des_trac_picture(1)='cloud_water'
-  des_trac_picture(2)='rain'
-  des_trac_picture(3)='cloud_ice'
-  des_trac_picture(4)='graupel'
+  var_trac_picture(1) = 'watcnew'
+  var_trac_picture(2) = 'watpnew'
+  var_trac_picture(3) = 'icecnew'
+  var_trac_picture(4) = 'granew'
+  des_trac_picture(1) = 'cloud_water'
+  des_trac_picture(2) = 'rain'
+  des_trac_picture(3) = 'cloud_ice'
+  des_trac_picture(4) = 'graupel'
 /"""
         namelist = Namelist(input_str)
 
         self.assertEqual(namelist.dump(array_inline=False), input_str)
 
-    def test_inline_array(self):
+    def test_dump_inline_array(self):
         input_str = """&AADATA
-  AACOMPLEX= (3.,4.) (3.,4.) (5.,6.) (7.,7.)
+  AACOMPLEX = (3.000000,4.000000) (3.000000,4.000000) (5.000000,6.000000) (7.000000,7.000000)
 /"""
 
         namelist = Namelist(input_str)
-
-        print input_str
-        print namelist.dump()
 
         self.assertEqual(namelist.dump(), input_str)
 

--- a/namelist.py
+++ b/namelist.py
@@ -71,7 +71,7 @@ class Namelist():
             block_lines = group_block.split('\n')
             group_name = block_lines.pop(0).strip()
 
-            group = {}
+            group = OrderedDict()
 
             for line in block_lines:
                 line = line.strip()
@@ -193,12 +193,12 @@ class Namelist():
             for variable_name, variable_value in group_variables.items():
                 if isinstance(variable_value, list):
                     if array_inline:
-                        lines.append("%s= %s" % (variable_name, " ".join([self._format_value(v) for v in variable_value])))
+                        lines.append("  %s= %s" % (variable_name, " ".join([self._format_value(v) for v in variable_value])))
                     else:
                         for n, v in enumerate(variable_value):
-                            lines.append("%s(%d)=%s" % (variable_name, n+1, self._format_value(v)))
+                            lines.append("  %s(%d)=%s" % (variable_name, n+1, self._format_value(v)))
                 else:
-                    lines.append("%s=%s" % (variable_name, self._format_value(variable_value)))
+                    lines.append("  %s=%s" % (variable_name, self._format_value(variable_value)))
             lines.append("/")
 
         return "\n".join(lines)
@@ -447,7 +447,7 @@ class ParsingTests(unittest.TestCase):
 
     def test_dump_single_value(self):
         input_str = """&CCFMSIM_SETUP
-CCFMrad=800.000000
+  CCFMrad=800.000000
 /"""
         namelist = Namelist(input_str)
 
@@ -455,10 +455,10 @@ CCFMrad=800.000000
 
     def test_dump_multigroup(self):
         input_str = """&CCFMSIM_SETUP
-CCFMrad=800.000000
+  CCFMrad=800.000000
 /
 &GROUP2
-R=500.000000
+  R=500.000000
 /"""
         namelist = Namelist(input_str)
 
@@ -467,14 +467,14 @@ R=500.000000
 
     def test_dump_array(self):
         input_str = """&CCFMSIM_SETUP
-var_trac_picture(1)='watcnew'
-var_trac_picture(2)='watpnew'
-var_trac_picture(3)='icecnew'
-var_trac_picture(4)='granew'
-des_trac_picture(1)='cloud_water'
-des_trac_picture(2)='rain'
-des_trac_picture(3)='cloud_ice'
-des_trac_picture(4)='graupel'
+  var_trac_picture(1)='watcnew'
+  var_trac_picture(2)='watpnew'
+  var_trac_picture(3)='icecnew'
+  var_trac_picture(4)='granew'
+  des_trac_picture(1)='cloud_water'
+  des_trac_picture(2)='rain'
+  des_trac_picture(3)='cloud_ice'
+  des_trac_picture(4)='graupel'
 /"""
         namelist = Namelist(input_str)
 
@@ -482,7 +482,7 @@ des_trac_picture(4)='graupel'
 
     def test_dump_inline_array(self):
         input_str = """&AADATA
-AACOMPLEX= (3.000000,4.000000) (3.000000,4.000000) (5.000000,6.000000) (7.000000,7.000000)
+  AACOMPLEX= (3.000000,4.000000) (3.000000,4.000000) (5.000000,6.000000) (7.000000,7.000000)
 /"""
 
         namelist = Namelist(input_str)


### PR DESCRIPTION
@leifdenby I changed the output to include two spaces before each namelist group object and also used OrderedDict instead of normal dict for the namelist group objects. This means that the name = value pairs within each group do not switch places in consecutive writes.
Fortran doesn't care about the order, but it's much easier to read, compare and check namelist manually if the order of the entries is always the same.
