### PR TITLE
ENH: read simple multiline variable definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Out[9]: 4.0
  - Tab-completion and variable assignment in interactive console
 
 ## Missing features
- - Currently can't handle variable definitions across multiple lines
+ - Currently can't handle complex variable definitions across multiple lines
  - Comments are not kept, and so won't exist in output.
 
 ## Contribute

--- a/namelist_python/namelist.py
+++ b/namelist_python/namelist.py
@@ -69,19 +69,31 @@ class Namelist():
         group_cnt = {}
 
         for group_block in group_blocks:
-            block_lines = group_block.split('\n')
-            group_name = block_lines.pop(0).strip()
+            block_lines_raw = group_block.split('\n')
+            group_name = block_lines_raw.pop(0).strip()
 
             group = OrderedDict()
 
-
-            for line in block_lines:
+            block_lines = []
+            for line in block_lines_raw:
+                # cleanup string
                 line = line.strip()
                 if line == "":
                     continue
                 if line.startswith('!'):
                     continue
 
+                try:
+                    k, v = line.split('=')
+                    block_lines.append(line)
+                except ValueError:
+                    # no = in current line, try to append to previous line
+                    if block_lines[-1].endswith(','):
+                        block_lines[-1] += line
+                    else:
+                        raise
+
+            for line in block_lines:
                 # commas at the end of lines seem to be optional
                 if line.endswith(','):
                     line = line[:-1]

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -295,3 +295,14 @@ def test_dump_inline_array():
     namelist = Namelist(input_str)
 
     assert namelist.dump() == input_str
+
+def test_multiline_variable():
+    input_str = """&AADATA
+  AACOMPLEX = 3., 4., 3., 4.,
+              5., 6., 7., 7.
+/"""
+
+    namelist = Namelist(input_str)
+
+    assert namelist.groups == {'AADATA': {'AACOMPLEX':
+                                          [3., 4., 3., 4., 5., 6., 7., 7.]}}


### PR DESCRIPTION
I don't know much about Python namelists, but have to work with those where variable definitions span more than one line.

This quick hack depends on the assumption that a variable definition which will
be continued on the next line ends with a comma - I don't know if this is okay according to the standard definition.  For my simple case it works.

Feel free to merge if you deem it appropriate.